### PR TITLE
Make model path relative to the source path to avoid invalid references

### DIFF
--- a/cli/teste_ds.py
+++ b/cli/teste_ds.py
@@ -12,21 +12,23 @@ from src.pipeline.inference_pipeline import make_batch_predictions
 
 
 def classify_product(product: str) -> None:
-    print(f'Classify Product: {product}')
     product_obj = Product(**json.loads(product))
     product_obj = fp.first(make_batch_predictions([product_obj]))
     print(product_obj.category)
 
 
 def classify_query(query: str) -> None:
-    print(f'Classify Query: {query}')
+    print(f'TBD: Classify Query: {query}')
 
 
 def recommend(query: str) -> None:
-    print(f'Recommend for Query: {query}')
+    print(f'TBD: Recommend for Query: {query}')
 
 
 def main():
+    print(__file__)
+    print(os.path.expanduser(__file__))
+    print(SCRIPT_DIR)
 
     task_function_map = {
         "classify": classify_product,

--- a/src/pipeline/training_pipeline.py
+++ b/src/pipeline/training_pipeline.py
@@ -14,7 +14,6 @@ def compute_embeddings_frame(base_frame: pd.DataFrame, columns: List[str],
     """Para cada coluna indicada, cria uma coluna com a representação de embeddings de cada elemento."""
 
     ft_model = fasttext.load_model(os.path.join(settings.MODELS_PATH, ft_model_ref))
-
     embeddings_frame = pd.DataFrame()
     for column in columns:
         embeddings_frame[f'{column}_embedding'] = (

--- a/src/settings.py
+++ b/src/settings.py
@@ -1,8 +1,10 @@
 import os
+from pathlib import Path
 
+SRC_PATH = os.path.dirname(os.path.realpath(os.path.join(os.getcwd(), os.path.expanduser(__file__))))
 RAW_DATASET_PATH = 'https://elo7-datasets.s3.amazonaws.com/data_scientist_position/elo7_recruitment_dataset.csv'
 DATA_PATH = os.path.join(os.pardir, 'data')
-MODELS_PATH = os.path.join(os.pardir, 'models')
+MODELS_PATH = Path(SRC_PATH).parent.joinpath('models')
 
 TRACKING_URI = os.path.join('notebooks', 'mlruns')
 LOGS_ARTIFACTS_PATH = os.path.join(os.pardir, 'data', 'log')


### PR DESCRIPTION
Correção de bug que impedia o modelo Word2vec de ser carregado executado por CLI. 